### PR TITLE
feat: add automatic TLS certificate management with ACME/Let's Encrypt support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,22 +3,6 @@
 version = 4
 
 [[package]]
-name = "acme-lib"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcfe879d8669cfe09f2dd1bef4dc8cb232ca7b9ce46f4621cda9e7cc729cf73"
-dependencies = [
- "base64 0.21.7",
- "lazy_static",
- "log",
- "openssl",
- "serde",
- "serde_json",
- "time",
- "ureq",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +108,17 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -251,12 +246,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -445,15 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,14 +454,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "deranged"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "powerfmt",
 ]
 
 [[package]]
@@ -531,16 +509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,21 +519,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -914,113 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
-
-[[package]]
-name = "icu_properties"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "potential_utf",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
-
-[[package]]
-name = "icu_provider"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +894,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant-acme"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1161,12 +1029,6 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "litemap"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1291,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,48 +1183,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "overload"
@@ -1388,6 +1218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,25 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
-name = "potential_utf"
-version = "0.1.2"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
-dependencies = [
- "zerovec",
-]
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1458,7 +1289,6 @@ dependencies = [
 name = "prox"
 version = "0.1.0"
 dependencies = [
- "acme-lib",
  "anyhow",
  "aws-lc-rs",
  "axum",
@@ -1476,9 +1306,10 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "instant-acme",
  "notify",
- "openssl",
  "rand",
+ "rcgen",
  "regex",
  "rustls",
  "rustls-native-certs 0.7.3",
@@ -1487,7 +1318,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
  "tower",
@@ -1562,6 +1393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -1920,12 +1764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,17 +1793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,11 +1807,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2010,24 +1857,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.1"
+name = "time-core"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tokio"
@@ -2229,39 +2074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,12 +2084,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"
@@ -2297,12 +2103,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2395,24 +2195,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2609,33 +2391,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.1"
+name = "yasna"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "yoke"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "time",
 ]
 
 [[package]]
@@ -2659,61 +2420,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "acme-lib"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcfe879d8669cfe09f2dd1bef4dc8cb232ca7b9ce46f4621cda9e7cc729cf73"
+dependencies = [
+ "base64 0.21.7",
+ "lazy_static",
+ "log",
+ "openssl",
+ "serde",
+ "serde_json",
+ "time",
+ "ureq",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +253,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +471,17 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -477,6 +525,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +545,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -835,6 +908,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1149,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1117,10 +1303,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1170,10 +1394,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1207,6 +1446,7 @@ dependencies = [
 name = "prox"
 version = "0.1.0"
 dependencies = [
+ "acme-lib",
  "anyhow",
  "aws-lc-rs",
  "axum",
@@ -1225,6 +1465,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "notify",
+ "openssl",
  "rand",
  "regex",
  "rustls",
@@ -1396,6 +1637,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1652,6 +1894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1929,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1967,27 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1910,6 +2190,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2233,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"
@@ -1939,6 +2258,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2031,6 +2356,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2227,6 +2570,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,7 +2620,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1486,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -1624,7 +1637,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1937,6 +1963,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2385,7 +2424,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 
 # ACME/Let's Encrypt dependencies
-acme-lib = "0.9"
-openssl = "0.10"
+instant-acme = "0.7.2"
+rcgen = "0.13"
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ governor = "0.10.0"
 humantime = "2.1.0"
 chrono = { version = "0.4", features = ["serde"] } 
 regex = "1"
+
+# ACME/Let's Encrypt dependencies
+acme-lib = "0.9"
+openssl = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ regex = "1"
 # ACME/Let's Encrypt dependencies
 acme-lib = "0.9"
 openssl = "0.10"
+
+[dev-dependencies]
+tempfile = "3.13"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ src/
 │   ├── http/             # HTTP server implementation
 │   │   ├── server.rs     # Hyper server implementation
 │   │   └── mod.rs
+│   ├── acme.rs           # ACME/Let's Encrypt certificate management
 │   ├── http_handler.rs   # HTTP request handler
 │   ├── http_client.rs    # HTTP client implementation
 │   ├── file_system.rs    # Static file handling

--- a/README.md
+++ b/README.md
@@ -69,24 +69,66 @@ src/
 
 ## Usage
 
+## Usage
+
+### Option 1: Manual TLS Certificates
+
 1. Generate self-signed certificates for HTTPS (or use your own):
    ```bash
    mkdir -p certs
    openssl req -x509 -newkey rsa:4096 -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes -subj '/CN=localhost'
    ```
 
-2. Configure your reverse proxy in `config.yaml`
+2. Configure your reverse proxy in `config.yaml` with manual certificates
 
 3. Run the proxy: `cargo run`
 
-## Configuration Example
+### Option 2: Automatic TLS with Let's Encrypt (ACME)
+
+1. Configure your reverse proxy in `config.yaml` with ACME settings
+
+2. Ensure your domain points to your server and port 443 is accessible
+
+3. Run the proxy: `cargo run`
+
+**Note**: For ACME to work, your server must be publicly accessible on port 443, and the domains you specify must point to your server for HTTP-01 challenge validation.
+
+## Configuration Examples
+
+### Manual TLS Configuration
 
 ```yaml
-listen_addr: "127.0.0.1:3002"
-# TLS configuration
+listen_addr: "0.0.0.0:443"
+# Manual TLS configuration
 tls:
   cert_path: "./certs/cert.pem"
   key_path: "./certs/key.pem"
+
+# Health check configuration
+health_check:
+  enabled: true
+  interval_secs: 10
+  timeout_secs: 5
+  path: "/health"
+  unhealthy_threshold: 3
+  healthy_threshold: 2
+```
+
+### Automatic TLS with ACME/Let's Encrypt
+
+```yaml
+listen_addr: "0.0.0.0:443"
+# ACME configuration for automatic certificate management
+tls:
+  acme:
+    enabled: true
+    domains:
+      - "example.com"
+      - "www.example.com"
+    email: "admin@example.com"
+    staging: false  # Set to true for testing
+    storage_path: "./acme_storage"
+    renewal_days_before_expiry: 30
 
 # Health check configuration
 health_check:
@@ -174,6 +216,30 @@ routes:
       requests: 1000
       period: "1h"
 ```
+
+## ACME Configuration Options
+
+When using automatic TLS certificate management with ACME (Let's Encrypt), you can configure the following options:
+
+- **`enabled`**: Set to `true` to enable ACME certificate management
+- **`domains`**: List of domains to include in the certificate (first domain is the primary)
+- **`email`**: Contact email for Let's Encrypt account registration
+- **`staging`**: Set to `true` to use Let's Encrypt staging environment for testing (optional, defaults to `false`)
+- **`ca_url`**: Custom ACME CA URL (optional, defaults to Let's Encrypt production)
+- **`storage_path`**: Directory to store certificates and account data (optional, defaults to `./acme_storage`)
+- **`renewal_days_before_expiry`**: Days before expiry to renew certificates (optional, defaults to 30)
+
+### ACME Requirements
+
+1. **Public accessibility**: Your server must be publicly accessible on port 443
+2. **Domain DNS**: All domains in your configuration must point to your server's IP address
+3. **HTTP-01 challenge**: Prox automatically handles HTTP-01 challenges by serving files from `./static/.well-known/acme-challenge/`
+
+### ACME Certificate Renewal
+
+- Certificates are automatically checked daily for renewal
+- Renewal occurs when the certificate expires within the configured threshold (default: 30 days)
+- The renewal process runs in the background without interrupting service
 
 ## Testing
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,21 @@
 listen_addr: "127.0.0.1:3000"
 # TLS configuration - uncomment to enable TLS
 tls:
+  # Option 1: Manual certificates (existing approach) - ACTIVE FOR LOCAL TESTING
   cert_path: "./certs/cert.pem"
   key_path: "./certs/key.pem"
+  
+  # Option 2: Automatic ACME/Let's Encrypt certificates
+  # Comment out manual cert_path/key_path above and uncomment acme section below
+  # acme:
+  #   enabled: true
+  #   domains:
+  #     - "yourdomain.com"
+  #     - "www.yourdomain.com"
+  #   email: "your-email@example.com"  # Required for Let's Encrypt account
+  #   staging: true  # Set to true for testing with Let's Encrypt staging
+  #   storage_path: "./acme_storage"  # Where to store certificates and account info
+  #   renewal_days_before_expiry: 30  # Renew certificates 30 days before expiry
 
 # Health check configuration
 health_check:

--- a/docs/REVERSE_PROXY_VALUE_ADDITIONS.md
+++ b/docs/REVERSE_PROXY_VALUE_ADDITIONS.md
@@ -35,12 +35,16 @@ This document outlines current major problems with reverse proxies and proposes 
 
 ---
 
-## 4. Automatic TLS Certificate Management ✅ (Partially Implemented)
+## 4. Automatic TLS Certificate Management ✅ (Implemented)
 **Problem:** Manual certificate management is error-prone and not scalable.
 
-**Solution:**
+**Solution:** *Fully implemented in Prox.*
 - Prox supports TLS with user-provided certificates (see README for setup).
-- Automatic certificate provisioning/renewal (ACME/Let's Encrypt) is *planned*.
+- **NEW**: Automatic certificate provisioning/renewal using ACME/Let's Encrypt is now fully implemented.
+- Supports both staging and production Let's Encrypt environments.
+- Automatic daily certificate renewal checks.
+- HTTP-01 challenge validation.
+- Configurable storage paths and renewal thresholds.
 
 ---
 
@@ -190,7 +194,7 @@ This document outlines current major problems with reverse proxies and proposes 
 | Config reload               | Hot-reload, no downtime                               | ✅ Implemented |
 | Observability               | Metrics, tracing, dashboard                           | Planned        |
 | Rate limiting               | Flexible, multi-key, dynamic                          | ✅ Implemented |
-| TLS management              | User-provided certs (auto/ACME planned)               | ✅/Planned     |
+| TLS management              | User-provided certs + auto ACME/Let's Encrypt     | ✅ Implemented |
 | Graceful restarts           | Zero-downtime, socket passing                         | Planned        |
 | AuthN/AuthZ                 | Built-in, pluggable                                   | Planned        |
 | Service discovery           | Dynamic, Consul, DNS, health checks                   | Partial (Health checks implemented) |

--- a/src/adapters/acme.rs
+++ b/src/adapters/acme.rs
@@ -1,0 +1,425 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use acme_lib::{Directory, DirectoryUrl, create_p384_key, persist::FilePersist};
+use anyhow::{Context, Result, anyhow};
+use openssl::x509::X509;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+use crate::config::models::AcmeConfig;
+
+pub struct AcmeService {
+    config: AcmeConfig,
+    storage_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct CertificateInfo {
+    pub cert_path: String,
+    pub key_path: String,
+    pub expires_at: SystemTime,
+}
+
+impl AcmeService {
+    pub fn new(config: AcmeConfig) -> Result<Self> {
+        let storage_path = PathBuf::from(
+            config
+                .storage_path
+                .as_ref()
+                .unwrap_or(&"./acme_storage".to_string()),
+        );
+
+        // Create storage directory if it doesn't exist
+        fs::create_dir_all(&storage_path).with_context(|| {
+            format!(
+                "Failed to create ACME storage directory: {:?}",
+                storage_path
+            )
+        })?;
+
+        Ok(Self {
+            config,
+            storage_path,
+        })
+    }
+
+    /// Get the ACME directory URL based on configuration
+    fn get_directory_url(&self) -> DirectoryUrl {
+        if let Some(ref ca_url) = self.config.ca_url {
+            DirectoryUrl::Other(ca_url)
+        } else if self.config.staging.unwrap_or(false) {
+            DirectoryUrl::LetsEncryptStaging
+        } else {
+            DirectoryUrl::LetsEncrypt
+        }
+    }
+
+    /// Get certificate paths for a domain
+    fn get_cert_paths(&self, domain: &str) -> (PathBuf, PathBuf) {
+        let cert_path = self.storage_path.join(format!("{}.crt", domain));
+        let key_path = self.storage_path.join(format!("{}.key", domain));
+        (cert_path, key_path)
+    }
+
+    /// Check if certificate exists and is valid
+    pub fn check_certificate(&self, domain: &str) -> Option<CertificateInfo> {
+        let (cert_path, key_path) = self.get_cert_paths(domain);
+
+        if !cert_path.exists() || !key_path.exists() {
+            return None;
+        }
+
+        // Check certificate expiration
+        match fs::read(&cert_path) {
+            Ok(cert_data) => {
+                match X509::from_pem(&cert_data) {
+                    Ok(cert) => {
+                        let not_after = cert.not_after();
+                        // Convert ASN1Time to SystemTime
+                        let expires_at = SystemTime::UNIX_EPOCH
+                            + Duration::from_secs(
+                                not_after
+                                    .diff(&openssl::asn1::Asn1Time::from_unix(0).unwrap())
+                                    .unwrap()
+                                    .days as u64
+                                    * 24
+                                    * 60
+                                    * 60,
+                            );
+
+                        let renewal_threshold_days =
+                            self.config.renewal_days_before_expiry.unwrap_or(30);
+
+                        if SystemTime::now()
+                            + Duration::from_secs(renewal_threshold_days * 24 * 60 * 60)
+                            < expires_at
+                        {
+                            info!("Valid certificate found for domain: {}", domain);
+                            let cert_info = CertificateInfo {
+                                cert_path: cert_path.to_string_lossy().to_string(),
+                                key_path: key_path.to_string_lossy().to_string(),
+                                expires_at,
+                            };
+                            cert_info.log_info();
+                            return Some(cert_info);
+                        } else {
+                            info!(
+                                "Certificate for domain {} expires soon, needs renewal",
+                                domain
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to parse certificate for domain {}: {}", domain, e);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Failed to read certificate for domain {}: {}", domain, e);
+            }
+        }
+
+        None
+    }
+
+    /// Request a new certificate for the given domains
+    pub async fn request_certificate(&self, domains: &[String]) -> Result<CertificateInfo> {
+        if domains.is_empty() {
+            return Err(anyhow!("No domains specified for certificate request"));
+        }
+
+        let primary_domain = &domains[0];
+        info!("Requesting certificate for domains: {:?}", domains);
+
+        // Setup file persistence for ACME account
+        let persist = FilePersist::new(&self.storage_path);
+
+        // Create directory and account
+        let dir = Directory::from_url(persist, self.get_directory_url())?;
+        let acc = dir.account(&self.config.email)?;
+
+        // Create order for domains
+        let mut ord_new = acc.new_order(primary_domain, &[])?;
+
+        // Go through all authorizations
+        let ord_csr = loop {
+            if let Some(ord_csr) = ord_new.confirm_validations() {
+                break ord_csr;
+            }
+
+            let auths = ord_new.authorizations()?;
+
+            for auth in auths {
+                let chall = auth.http_challenge();
+                let token = chall.http_token();
+                let proof = chall.http_proof();
+
+                info!(
+                    "Setting up HTTP challenge for domain: {}",
+                    auth.domain_name()
+                );
+                info!("Token: {}, Proof: {}", token, proof);
+
+                // Create challenge directory and file
+                let well_known_path = Path::new("./static/.well-known/acme-challenge");
+                fs::create_dir_all(well_known_path)
+                    .with_context(|| "Failed to create .well-known directory")?;
+
+                let challenge_file = well_known_path.join(token);
+                fs::write(&challenge_file, proof)
+                    .with_context(|| "Failed to write challenge file")?;
+
+                info!("Created challenge file: {:?}", challenge_file);
+
+                // Validate challenge
+                chall.validate(5000)?;
+
+                // Clean up challenge file
+                let _ = fs::remove_file(&challenge_file);
+                info!("Challenge validated for domain: {}", auth.domain_name());
+            }
+
+            ord_new.refresh()?;
+        };
+
+        // Generate private key and certificate signing request
+        let pkey_pri = create_p384_key();
+        let ord_cert = ord_csr.finalize_pkey(pkey_pri, 5000)?;
+        let cert = ord_cert.download_and_save_cert()?;
+
+        // Save certificate and private key to our custom paths
+        let (cert_path, key_path) = self.get_cert_paths(primary_domain);
+
+        fs::write(&cert_path, cert.certificate()).with_context(|| "Failed to save certificate")?;
+        fs::write(&key_path, cert.private_key()).with_context(|| "Failed to save private key")?;
+
+        info!(
+            "Certificate saved for domain: {} at {:?}",
+            primary_domain, cert_path
+        );
+
+        // Parse certificate to get expiration time
+        let cert_x509 = X509::from_pem(cert.certificate().as_bytes())
+            .with_context(|| "Failed to parse saved certificate")?;
+        let not_after = cert_x509.not_after();
+        let expires_at = SystemTime::UNIX_EPOCH
+            + Duration::from_secs(
+                not_after
+                    .diff(&openssl::asn1::Asn1Time::from_unix(0).unwrap())
+                    .unwrap()
+                    .days as u64
+                    * 24
+                    * 60
+                    * 60,
+            );
+
+        Ok(CertificateInfo {
+            cert_path: cert_path.to_string_lossy().to_string(),
+            key_path: key_path.to_string_lossy().to_string(),
+            expires_at,
+        })
+    }
+
+    /// Get certificate for the configured domains, requesting new one if needed
+    pub async fn get_certificate(&self) -> Result<CertificateInfo> {
+        if self.config.domains.is_empty() {
+            return Err(anyhow!("No domains configured for ACME"));
+        }
+
+        // Check for any expired certificates first
+        if self.has_expired_certificate() {
+            warn!("Found expired certificates! Certificate status for all domains:");
+            for (domain, cert_info) in self.get_certificate_status() {
+                match cert_info {
+                    Some(info) => {
+                        if info.is_expired() {
+                            error!("Domain '{}' has EXPIRED certificate!", domain);
+                        } else {
+                            info!(
+                                "Domain '{}' certificate expires in {} days",
+                                domain,
+                                info.days_until_expiry()
+                            );
+                        }
+                    }
+                    None => warn!("Domain '{}' has no certificate", domain),
+                }
+            }
+        }
+
+        let primary_domain = &self.config.domains[0];
+
+        // Check if we have a valid certificate
+        if let Some(cert_info) = self.check_certificate(primary_domain) {
+            cert_info.log_info();
+            return Ok(cert_info);
+        }
+
+        // Request new certificate
+        info!(
+            "No valid certificate found for domain: {}, requesting new certificate",
+            primary_domain
+        );
+        let cert_info = self.request_certificate(&self.config.domains).await?;
+        cert_info.log_info();
+        Ok(cert_info)
+    }
+
+    /// Start a background task to monitor and renew certificates
+    pub fn start_renewal_task(&self) -> tokio::task::JoinHandle<()> {
+        let config = self.config.clone();
+
+        tokio::spawn(async move {
+            let service = match AcmeService::new(config) {
+                Ok(service) => service,
+                Err(e) => {
+                    error!("Failed to create ACME service for renewal task: {}", e);
+                    return;
+                }
+            };
+
+            let check_interval = Duration::from_secs(24 * 60 * 60); // Check daily
+
+            loop {
+                sleep(check_interval).await;
+
+                info!("Checking certificate renewal status");
+
+                // Log status for all certificates
+                let cert_statuses = service.get_certificate_status();
+                info!(
+                    "Certificate status summary for {} domains:",
+                    cert_statuses.len()
+                );
+
+                for (domain, cert_info) in &cert_statuses {
+                    match cert_info {
+                        Some(info) => {
+                            let days_left = info.days_until_expiry();
+                            if info.is_expired() {
+                                error!(
+                                    "Domain '{}' certificate EXPIRED {} days ago!",
+                                    domain, -days_left
+                                );
+                            } else if days_left < 30 {
+                                warn!(
+                                    "Domain '{}' certificate expires in {} days",
+                                    domain, days_left
+                                );
+                            } else {
+                                info!(
+                                    "Domain '{}' certificate valid for {} days",
+                                    domain, days_left
+                                );
+                            }
+                        }
+                        None => warn!("Domain '{}' has no certificate", domain),
+                    }
+                }
+
+                // Check if we need to renew any certificates
+                let needs_renewal = service.has_expired_certificate()
+                    || cert_statuses.iter().any(|(_, cert_info)| {
+                        if let Some(info) = cert_info {
+                            let renewal_days =
+                                service.config.renewal_days_before_expiry.unwrap_or(30);
+                            info.expires_within_days(renewal_days)
+                        } else {
+                            true // No certificate means we need one
+                        }
+                    });
+
+                if needs_renewal {
+                    info!("Certificate renewal required");
+
+                    match service.request_certificate(&service.config.domains).await {
+                        Ok(cert_info) => {
+                            info!("Successfully renewed/obtained certificate");
+                            cert_info.log_info();
+                        }
+                        Err(e) => {
+                            error!("Failed to renew/obtain certificate: {}", e);
+                        }
+                    }
+                } else {
+                    info!("All certificates are valid and don't need renewal yet");
+                }
+            }
+        })
+    }
+
+    /// Check if any of the configured domains has an expired certificate
+    pub fn has_expired_certificate(&self) -> bool {
+        for domain in &self.config.domains {
+            if let Some(cert_info) = self.check_certificate(domain) {
+                if cert_info.is_expired() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Get certificate status for all configured domains
+    pub fn get_certificate_status(&self) -> Vec<(String, Option<CertificateInfo>)> {
+        self.config
+            .domains
+            .iter()
+            .map(|domain| {
+                let cert_info = self.check_certificate(domain);
+                (domain.clone(), cert_info)
+            })
+            .collect()
+    }
+}
+
+impl CertificateInfo {
+    /// Check if the certificate is expired
+    #[allow(dead_code)]
+    pub fn is_expired(&self) -> bool {
+        SystemTime::now() >= self.expires_at
+    }
+
+    /// Check if the certificate will expire within the given number of days
+    pub fn expires_within_days(&self, days: u64) -> bool {
+        let threshold = SystemTime::now() + Duration::from_secs(days * 24 * 60 * 60);
+        threshold >= self.expires_at
+    }
+
+    /// Get the number of days until expiration (negative if expired)
+    pub fn days_until_expiry(&self) -> i64 {
+        match self.expires_at.duration_since(SystemTime::now()) {
+            Ok(duration) => (duration.as_secs() / (24 * 60 * 60)) as i64,
+            Err(_) => {
+                // Certificate is expired
+                match SystemTime::now().duration_since(self.expires_at) {
+                    Ok(duration) => -((duration.as_secs() / (24 * 60 * 60)) as i64),
+                    Err(_) => 0,
+                }
+            }
+        }
+    }
+
+    /// Log certificate information
+    pub fn log_info(&self) {
+        let days_until_expiry = self.days_until_expiry();
+        if days_until_expiry < 0 {
+            error!(
+                "Certificate EXPIRED {} days ago! cert={}",
+                -days_until_expiry, self.cert_path
+            );
+        } else if days_until_expiry < 30 {
+            warn!(
+                "Certificate expires in {} days. cert={}",
+                days_until_expiry, self.cert_path
+            );
+        } else {
+            info!(
+                "Certificate valid for {} days. cert={}",
+                days_until_expiry, self.cert_path
+            );
+        }
+    }
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,3 +1,4 @@
+pub mod acme;
 pub mod file_system;
 pub mod health_checker;
 pub mod http;

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -84,11 +84,22 @@ impl ServerConfigBuilder {
         self
     }
 
-    /// Set TLS configuration
+    /// Set TLS configuration with manual certificate paths
     pub fn tls(mut self, cert_path: impl Into<String>, key_path: impl Into<String>) -> Self {
         self.tls = Some(TlsConfig {
-            cert_path: cert_path.into(),
-            key_path: key_path.into(),
+            cert_path: Some(cert_path.into()),
+            key_path: Some(key_path.into()),
+            acme: None,
+        });
+        self
+    }
+
+    /// Set ACME configuration for automatic certificate management
+    pub fn acme(mut self, acme_config: AcmeConfig) -> Self {
+        self.tls = Some(TlsConfig {
+            cert_path: None,
+            key_path: None,
+            acme: Some(acme_config),
         });
         self
     }
@@ -132,8 +143,23 @@ impl ServerConfigBuilder {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TlsConfig {
-    pub cert_path: String,
-    pub key_path: String,
+    // Manual certificate paths (existing functionality)
+    pub cert_path: Option<String>,
+    pub key_path: Option<String>,
+
+    // ACME configuration (new functionality)
+    pub acme: Option<AcmeConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AcmeConfig {
+    pub enabled: bool,
+    pub domains: Vec<String>,
+    pub email: String,
+    pub ca_url: Option<String>, // Default to Let's Encrypt production
+    pub staging: Option<bool>,  // Use Let's Encrypt staging for testing
+    pub storage_path: Option<String>, // Where to store certificates and private keys
+    pub renewal_days_before_expiry: Option<u64>, // How many days before expiry to renew
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
This pull request introduces support for automatic TLS certificate management using ACME/Let's Encrypt, along with improvements to the documentation and updates to the configuration model. The most important changes include adding ACME functionality to the server, updating configuration options, enhancing documentation, and refactoring related code.

### ACME/Let's Encrypt Integration:
* **`src/adapters/http/server.rs`**: Added logic to handle ACME certificate provisioning, renewal, and validation, including fallback to manual certificates if ACME is not enabled. Introduced an `AcmeService` to manage ACME operations. [[1]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L97-R102) [[2]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L181-R239)
* **`src/config/models.rs`**: Updated `TlsConfig` to support both manual certificate paths and ACME configuration. Added methods to set ACME configurations in `ServerConfigBuilder`. [[1]](diffhunk://#diff-8a82d45327c8c3004333e8ebae1fbf508fbf8e4a921c48eda1ada50daabce97bL87-R102) [[2]](diffhunk://#diff-8a82d45327c8c3004333e8ebae1fbf508fbf8e4a921c48eda1ada50daabce97bL135-R162)
* **`src/adapters/mod.rs`**: Added a new `acme` module to encapsulate ACME-related functionality.

### Configuration Updates:
* **`config.yaml`**: Introduced options for ACME configuration, including enabling ACME, specifying domains, and setting renewal thresholds. Provided clear instructions for switching between manual and ACME TLS setups.

### Documentation Enhancements:
* **`README.md`**: Expanded usage instructions to include ACME setup and requirements. Added examples for both manual and automatic TLS configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220-R243)
* **`docs/REVERSE_PROXY_VALUE_ADDITIONS.md`**: Updated documentation to reflect full implementation of ACME/Let's Encrypt support, highlighting features like automatic renewal and HTTP-01 challenge handling. [[1]](diffhunk://#diff-bb79b468c4aea0a80e5b71f23346d6987e27c85dfa66abfd4697f843e33b42c5L38-R47) [[2]](diffhunk://#diff-bb79b468c4aea0a80e5b71f23346d6987e27c85dfa66abfd4697f843e33b42c5L193-R197)

### Dependency Additions:
* **`Cargo.toml`**: Added `instant-acme` and `rcgen` dependencies to support ACME operations.

These changes collectively enhance the project's functionality by simplifying TLS management and improving user experience through automatic certificate handling.