### PR TITLE
refactor: HTTP/3 handler and server logic

### DIFF
--- a/src/adapters/file_system.rs
+++ b/src/adapters/file_system.rs
@@ -60,6 +60,5 @@ mod tests {
     fn test_default_construction() {
         let _fs1 = TowerFileSystem::new();
         let _fs2 = TowerFileSystem {};
-        // Both instantiation methods are valid and equivalent
     }
 }

--- a/src/adapters/http/server.rs
+++ b/src/adapters/http/server.rs
@@ -220,7 +220,11 @@ async fn update_config_handler(
     {
         let mut config_w = app_state.config_holder.write().map_err(|e| {
             tracing::error!("Failed to acquire config write lock: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update configuration").into_response()
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to update configuration",
+            )
+                .into_response()
         })?;
         *config_w = new_config_arc.clone();
         tracing::info!("(API Reload) Global ServerConfig Arc updated.");
@@ -231,7 +235,11 @@ async fn update_config_handler(
     {
         let mut proxy_s_w = app_state.proxy_service_holder.write().map_err(|e| {
             tracing::error!("Failed to acquire proxy service write lock: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to update proxy service").into_response()
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to update proxy service",
+            )
+                .into_response()
         })?;
         *proxy_s_w = new_proxy_service.clone();
         tracing::info!("(API Reload) Global ProxyService Arc updated.");
@@ -270,9 +278,11 @@ impl HttpServer for HyperServer {
 
         // Read values from config_guard and then drop it
         let (listen_addr_str, tls_config_opt_owned, protocols_config) = {
-            let config_guard = self.app_state.config_holder.read().map_err(|e| {
-                anyhow::anyhow!("Failed to acquire config read lock: {}", e)
-            })?;
+            let config_guard = self
+                .app_state
+                .config_holder
+                .read()
+                .map_err(|e| anyhow::anyhow!("Failed to acquire config read lock: {}", e))?;
             let addr_str = config_guard.listen_addr.clone();
             let tls_opt = config_guard.tls.clone(); // Clone the Option<TlsConfig>
             let protocols = config_guard.protocols.clone(); // Clone the ProtocolConfig

--- a/src/adapters/http3/connection.rs
+++ b/src/adapters/http3/connection.rs
@@ -73,7 +73,6 @@ impl QuicConnection {
         fin: bool,
     ) -> Result<()> {
         if let Some(ref mut h3_conn) = self.h3_connection {
-            // Send headers
             h3_conn
                 .send_response(
                     &mut self.connection,
@@ -83,7 +82,6 @@ impl QuicConnection {
                 )
                 .map_err(|e| anyhow::anyhow!("Failed to send response headers: {}", e))?;
 
-            // Send body if present
             if let Some(body_data) = body {
                 h3_conn
                     .send_body(&mut self.connection, stream_id, &body_data, fin)
@@ -133,14 +131,12 @@ impl ConnectionManager {
         let conn_id_vec = conn_id.to_vec();
 
         if let std::collections::hash_map::Entry::Vacant(e) = connections.entry(conn_id_vec) {
-            // Create a new config for this connection
             let quiche_config = self.create_quiche_config()?;
             let mut config = quiche_config.into_inner();
 
             let mut quic_conn =
                 QuicConnection::new(conn_id, odcid, local_addr, peer_addr, &mut config)?;
 
-            // Establish HTTP/3 connection if QUIC handshake is complete
             if quic_conn.connection().is_established() {
                 quic_conn.establish_h3(&self.h3_config)?;
             }
@@ -158,7 +154,6 @@ impl ConnectionManager {
         let mut connections = self.connections.lock().await;
 
         if let Some(quic_conn) = connections.get_mut(conn_id) {
-            // Try to establish HTTP/3 connection if not already done
             if quic_conn.h3_connection().is_none() && quic_conn.connection().is_established() {
                 quic_conn.establish_h3(&self.h3_config)?;
             }

--- a/src/adapters/http3/tests.rs
+++ b/src/adapters/http3/tests.rs
@@ -42,7 +42,6 @@ mod http3_tests {
 
     #[test]
     fn test_http3_config_validation_ranges() {
-        // Test minimum values
         let min_config = Http3Config {
             max_data: 1024,
             max_stream_data: 1024,
@@ -58,7 +57,6 @@ mod http3_tests {
         assert!(min_config.max_streams_bidi >= 1);
         assert!(min_config.max_idle_timeout >= 1000);
 
-        // Test maximum reasonable values
         let max_config = Http3Config {
             max_data: 1_000_000_000,
             max_stream_data: 100_000_000,
@@ -77,7 +75,6 @@ mod http3_tests {
 
     #[test]
     fn test_bytes_creation() {
-        // Test Bytes creation for HTTP/3 request bodies
         let empty_body: Option<Bytes> = None;
         let some_body = Bytes::from("test body");
 
@@ -87,7 +84,6 @@ mod http3_tests {
 
     #[test]
     fn test_socket_addr_parsing() {
-        // Test socket address parsing for HTTP/3 server binding
         let addr: SocketAddr = "127.0.0.1:3000".parse().expect("Failed to parse address");
 
         assert_eq!(addr.ip().to_string(), "127.0.0.1");
@@ -96,20 +92,13 @@ mod http3_tests {
 
     #[test]
     fn test_h3_header_conversion() {
-        // Test HTTP/3 header name-value pairs
         let method_header = H3Header::new(b":method", b"GET");
         let path_header = H3Header::new(b":path", b"/test");
         let authority_header = H3Header::new(b":authority", b"example.com");
 
-        // Verify headers are created successfully
-        // Note: H3Header::new returns a Header directly, not a Result
-        // We can test by creating them without panicking
         drop(method_header);
         drop(path_header);
         drop(authority_header);
-
-        // Test successful creation
-        // Headers were created without panicking - test passes
     }
 
     #[test]
@@ -141,7 +130,6 @@ mod http3_tests {
 
     #[test]
     fn test_config_optional_fields() {
-        // Test config with None max_packet_size
         let config_without_max_packet = Http3Config {
             max_data: 10_000_000,
             max_stream_data: 1_000_000,
@@ -155,7 +143,6 @@ mod http3_tests {
         assert!(config_without_max_packet.max_packet_size.is_none());
         assert!(!config_without_max_packet.enable_0rtt);
 
-        // Test config with Some max_packet_size
         let config_with_max_packet = Http3Config {
             max_data: 10_000_000,
             max_stream_data: 1_000_000,

--- a/src/adapters/http_handler.rs
+++ b/src/adapters/http_handler.rs
@@ -114,18 +114,19 @@ impl HyperHandler {
         }
     }
 
-    fn compute_final_path(original_path: &str, prefix: &str, path_rewrite: Option<&str>) -> String {            if let Some(rewrite_template) = path_rewrite {
-                let stripped_path = if let Some(stripped) = original_path.strip_prefix(prefix) {
-                    stripped
-                } else {
-                    tracing::warn!(
-                        original_path = %original_path,
-                        prefix = %prefix,
-                        "Original path does not start with the expected prefix during path rewrite. This might indicate an internal logic issue."
-                    );
-                    return String::new();
-                };
-                if rewrite_template == "/" {
+    fn compute_final_path(original_path: &str, prefix: &str, path_rewrite: Option<&str>) -> String {
+        if let Some(rewrite_template) = path_rewrite {
+            let stripped_path = if let Some(stripped) = original_path.strip_prefix(prefix) {
+                stripped
+            } else {
+                tracing::warn!(
+                    original_path = %original_path,
+                    prefix = %prefix,
+                    "Original path does not start with the expected prefix during path rewrite. This might indicate an internal logic issue."
+                );
+                return String::new();
+            };
+            if rewrite_template == "/" {
                 stripped_path.to_string()
             } else {
                 format!(
@@ -463,7 +464,11 @@ impl HyperHandler {
             Some(target) => target,
             None => {
                 tracing::error!("Proxy route missing target configuration");
-                return (StatusCode::INTERNAL_SERVER_ERROR, "Proxy route missing target configuration").into_response();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Proxy route missing target configuration",
+                )
+                    .into_response();
             }
         };
         let mut req = args.req; // Make req mutable from args
@@ -549,7 +554,7 @@ impl HyperHandler {
                         Self::build_response_with_fallback(
                             status_code,
                             format!("Proxy request failed: {e}"),
-                            "proxy error response"
+                            "proxy error response",
                         )
                     }
                 }
@@ -563,7 +568,7 @@ impl HyperHandler {
                 Self::build_response_with_fallback(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Failed to parse target URI",
-                    "URI parsing failure"
+                    "URI parsing failure",
                 )
             }
         }
@@ -574,14 +579,22 @@ impl HyperHandler {
             Some(targets) => targets,
             None => {
                 tracing::error!("Load balance route missing targets configuration");
-                return (StatusCode::INTERNAL_SERVER_ERROR, "Load balance route missing targets configuration").into_response();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Load balance route missing targets configuration",
+                )
+                    .into_response();
             }
         };
         let strategy = match args.strategy {
             Some(strategy) => strategy,
             None => {
                 tracing::error!("Load balance route missing strategy configuration");
-                return (StatusCode::INTERNAL_SERVER_ERROR, "Load balance route missing strategy configuration").into_response();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Load balance route missing strategy configuration",
+                )
+                    .into_response();
             }
         };
         let mut req = args.req; // Make req mutable from args
@@ -705,7 +718,7 @@ impl HyperHandler {
                         Self::build_response_with_fallback(
                             status_code,
                             format!("Load balanced request failed: {e}"),
-                            "load balancer error response"
+                            "load balancer error response",
                         )
                     }
                 }
@@ -719,7 +732,7 @@ impl HyperHandler {
                 Self::build_response_with_fallback(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Failed to parse load balanced target URI",
-                    "load balancer URI parsing failure"
+                    "load balancer URI parsing failure",
                 )
             }
         }
@@ -830,10 +843,7 @@ impl HyperHandler {
     }
 
     // Helper function for redirect responses
-    fn build_redirect_response(
-        status: StatusCode,
-        location: String,
-    ) -> AxumResponse {
+    fn build_redirect_response(status: StatusCode, location: String) -> AxumResponse {
         Response::builder()
             .status(status)
             .header("Location", location)
@@ -909,11 +919,19 @@ impl HttpHandler for HyperHandler {
                                 temp_req_builder = temp_req_builder.header(name, value);
                             }
                             // Pass an empty body for the check, actual body is preserved.
-                            let temp_req_for_check = match temp_req_builder.body(AxumBody::empty()) {
+                            let temp_req_for_check = match temp_req_builder.body(AxumBody::empty())
+                            {
                                 Ok(req) => req,
                                 Err(e) => {
-                                    tracing::error!("Failed to build temporary request for rate limiting: {}", e);
-                                    return Ok((StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response());
+                                    tracing::error!(
+                                        "Failed to build temporary request for rate limiting: {}",
+                                        e
+                                    );
+                                    return Ok((
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        "Internal server error",
+                                    )
+                                        .into_response());
                                 }
                             };
 

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -19,25 +19,19 @@ pub enum ConfigError {
 
 pub type ConfigResult<T> = std::result::Result<T, ConfigError>;
 
-/// Load and validate configuration from file
 pub async fn load_config<P: AsRef<Path>>(path: P) -> ConfigResult<ServerConfig> {
     let config_content = fs::read_to_string(path).await?;
     let config: ServerConfig = serde_yaml::from_str(&config_content)?;
-
-    // Validate the configuration
     ConfigValidator::validate(&config)?;
-
     Ok(config)
 }
 
-/// Load configuration from file without validation (for testing)
 pub async fn load_config_unchecked<P: AsRef<Path>>(path: P) -> ConfigResult<ServerConfig> {
     let config_content = fs::read_to_string(path).await?;
     let config: ServerConfig = serde_yaml::from_str(&config_content)?;
     Ok(config)
 }
 
-/// Validate configuration without loading from file
 pub fn validate_config(config: &ServerConfig) -> ConfigResult<()> {
     ConfigValidator::validate(config)?;
     Ok(())

--- a/src/core/backend.rs
+++ b/src/core/backend.rs
@@ -172,13 +172,11 @@ mod tests {
 
     #[test]
     fn test_backend_url_valid() {
-        // Test valid HTTP URL
         let url = "http://example.com";
         let backend_url = BackendUrl::new(url).expect("Valid HTTP URL should parse");
         assert_eq!(backend_url.as_str(), url);
         assert!(!backend_url.is_secure());
 
-        // Test valid HTTPS URL
         let secure_url = "https://secure.example.com";
         let secure_backend_url = BackendUrl::new(secure_url).expect("Valid HTTPS URL should parse");
         assert_eq!(secure_backend_url.as_str(), secure_url);
@@ -187,18 +185,15 @@ mod tests {
 
     #[test]
     fn test_backend_url_invalid() {
-        // Test invalid URL (no scheme)
         let result = BackendUrl::new("example.com");
         assert!(result.is_err());
 
-        // Test with other invalid schemes
         let result = BackendUrl::new("ftp://example.com");
         assert!(result.is_err());
     }
 
     #[test]
     fn test_backend_url_from_str() {
-        // Test FromStr implementation
         let url = "http://example.com";
         let backend_url: BackendUrl = url
             .parse()
@@ -208,7 +203,6 @@ mod tests {
 
     #[test]
     fn test_backend_url_display() {
-        // Test Display implementation
         let url = "http://example.com";
         let backend_url =
             BackendUrl::new(url).expect("Creating BackendUrl from valid string should succeed");
@@ -219,9 +213,8 @@ mod tests {
     fn test_backend_health_transitions() {
         let url = BackendUrl::new("http://example.com")
             .expect("Creating BackendUrl for health test should succeed");
-        let health = BackendHealth::new(url.clone()); // Pass clone of url if BackendHealth takes ownership, or just url if it takes a ref or copies
+        let health = BackendHealth::new(url.clone());
 
-        // Initial state
         assert_eq!(health.status(), HealthStatus::Healthy);
         assert_eq!(health.consecutive_successes(), 0);
         assert_eq!(health.consecutive_failures(), 0);

--- a/src/core/rate_limiter.rs
+++ b/src/core/rate_limiter.rs
@@ -16,23 +16,17 @@ use governor::{Quota, RateLimiter};
 
 use crate::config::models::{MissingKeyPolicy, RateLimitAlgorithm, RateLimitBy, RateLimitConfig};
 
-// --- LimiterWrapper Definition ---
-// LimiterWrapper holds a RateLimiter instance and the response details for when the limit is exceeded.
-// RL is the specific type of governor::RateLimiter.
 #[derive(Clone)]
 pub struct LimiterWrapper<RL> {
     pub limiter: RL,
     pub status_code: StatusCode,
     pub message: String,
-    pub on_missing_key: MissingKeyPolicy, // Added field
+    pub on_missing_key: MissingKeyPolicy,
 }
 
-// --- Type Aliases for specific RateLimiter configurations ---
 pub type DirectRateLimiterImpl = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 pub type KeyedRateLimiterImpl<K> = RateLimiter<K, DashMapStateStore<K>, DefaultClock>;
 
-// --- Type Aliases for specific LimiterWrappers ---
-// These wrap the RateLimiter implementations with custom error responses.
 pub type RouteSpecificLimiter = LimiterWrapper<DirectRateLimiterImpl>;
 pub type IpLimiter = LimiterWrapper<KeyedRateLimiterImpl<IpAddr>>;
 pub type HeaderLimiter = LimiterWrapper<KeyedRateLimiterImpl<String>>;

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -3,11 +3,6 @@ use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::Subscr
 pub fn init_tracing() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     tracing::info!("Initializing structured logging with JSON output");
 
-    // Configure structured logging with JSON output and span information
-    // This provides comprehensive observability including request tracing,
-    // which works seamlessly with the Prometheus metrics implementation
-
-    // Set up subscriber with JSON logging
     Registry::default()
         .with(EnvFilter::from_default_env())
         .with(


### PR DESCRIPTION
This pull request primarily removes redundant comments across various files to improve code readability and maintainability. The changes span multiple HTTP/3-related modules and focus on cleaning up comments that restate the code's functionality or provide unnecessary explanations.

### Removal of redundant comments:

#### `src/adapters/file_system.rs`:
* Removed a comment explaining the equivalence of two instantiation methods in the `test_default_construction` test.

#### `src/adapters/http/server.rs`:
* Removed comments describing basic functionality, such as RAII guards, shared state definitions, cloning operations, and error handling improvements. [[1]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L36) [[2]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L47) [[3]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L103-L104) [[4]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L225-R235) [[5]](diffhunk://#diff-99cb7eedd8616ad7132d8b4fa3d7943be159d81bbf0025c6e8146842e6dbdc60L271-R275)

#### `src/adapters/http3/config.rs`:
* Removed comments explaining QUIC configuration steps, including application protocol setup, flow control, congestion control, and certificate loading. [[1]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL23-L55) [[2]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL64) [[3]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL96-L103) [[4]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL119-R116)

#### `src/adapters/http3/connection.rs`:
* Removed comments describing HTTP/3 connection setup, response handling, and connection management logic. [[1]](diffhunk://#diff-8a5f7704bee1b0f64c4e313f7620fc554110b8a3f12c2c9997500f998ed31c35L76) [[2]](diffhunk://#diff-8a5f7704bee1b0f64c4e313f7620fc554110b8a3f12c2c9997500f998ed31c35L86) [[3]](diffhunk://#diff-8a5f7704bee1b0f64c4e313f7620fc554110b8a3f12c2c9997500f998ed31c35L136-L143) [[4]](diffhunk://#diff-8a5f7704bee1b0f64c4e313f7620fc554110b8a3f12c2c9997500f998ed31c35L161)

#### `src/adapters/http3/handler.rs`:
* Removed comments explaining HTTP/3 request and response processing, header conversion, and proxy service routing. [[1]](diffhunk://#diff-ed52a818f2cba7693b223a9c4ca859b190d392983bda2b8d91b7e309e9d62afaL36-L45) [[2]](diffhunk://#diff-ed52a818f2cba7693b223a9c4ca859b190d392983bda2b8d91b7e309e9d62afaL79) [[3]](diffhunk://#diff-ed52a818f2cba7693b223a9c4ca859b190d392983bda2b8d91b7e309e9d62afaL92) [[4]](diffhunk://#diff-ed52a818f2cba7693b223a9c4ca859b190d392983bda2b8d91b7e309e9d62afaL124-L140)

#### `src/adapters/http3/server.rs`:
* Removed comments describing UDP socket creation, QUIC packet processing, and HTTP/3 event handling. [[1]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L27-L41) [[2]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L55-L58) [[3]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L69-L95) [[4]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L116-L147)

#### Test files:
* Removed comments in test files (`src/adapters/http3/config.rs`, `src/adapters/http3/server.rs`, `src/adapters/http3/tests.rs`) that redundantly describe test setups and expected outcomes. [[1]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL96-L103) [[2]](diffhunk://#diff-e54a053844f5ffe0ab25a976f92c748b01997b8752e5bdab9ad45b3145f46abbL119-R116) [[3]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L190) [[4]](diffhunk://#diff-c04f4d95590a54afddda49725605e473107e3ddd48e777b6dec9ebb18e7c2716L199-L214) [[5]](diffhunk://#diff-738b2ddbed62850b0834692f33ed3b5f6f3e6d126e9072e6d27013aea2f8b022L45) [[6]](diffhunk://#diff-738b2ddbed62850b0834692f33ed3b5f6f3e6d126e9072e6d27013aea2f8b022L61) [[7]](diffhunk://#diff-738b2ddbed62850b0834692f33ed3b5f6f3e6d126e9072e6d27013aea2f8b022L80)